### PR TITLE
# [HIGH] Com_ars returned a 403 error after saving an item which aborted...

### DIFF
--- a/releasemaker/ars/ars.php
+++ b/releasemaker/ars/ars.php
@@ -258,6 +258,7 @@ class ArmArs
 			'view'			=> 'items',
 			'task'			=> 'save',
 			'format'		=> 'json',
+			'returnurl'		=> base64_encode('index.php'),
 		);
 		$arsData = array_merge($itemData, $arsData);
 


### PR DESCRIPTION
... ARM

Akeeba Release Maker threw the error "cURL error 22. The requested URL returned error: 403 Forbidden".

This was because:
1. F0F redirects to index.php?option=com_ars&view=items of the frontend _after_ saving the item, without including _fofauthentication.
2. onBeforeDispatch() of com_ars doesn't allow access to this frontend URL when not logged in and it throws a 403.
3. This 403 is detected by ArmArs->doApiCall() and throws the error "cURL error 22. The requested URL returned error: 403 Forbidden".

We prevent the 403 by setting a public redirect URL.

See: https://github.com/akeeba/releasemaker/issues/6
