### PR TITLE
Allow for multiple items to be published in the same release

### DIFF
--- a/src/Step/Items.php
+++ b/src/Step/Items.php
@@ -176,13 +176,12 @@ class Items extends AbstractStep
 				$itemMeta = json_decode($result);
 
 				$this->io->success(sprintf("Item %u has been $action", $itemMeta->id));
-
-				return;
 			}
+            else {
+                $this->io->error("Failed to create item");
 
-			$this->io->error("Failed to create item");
-
-			throw new FatalProblem(sprintf("Failed to create item for file %s, uploaded via %s", $filename, $type), 40);
-		}
+                throw new FatalProblem(sprintf("Failed to create item for file %s, uploaded via %s", $filename, $type), 40);
+            }
+        }
 	}
 }

--- a/src/Step/Publish.php
+++ b/src/Step/Publish.php
@@ -92,11 +92,11 @@ class Publish extends AbstractStep
 			if ($result !== false)
 			{
 				$this->io->success(sprintf("Item %u has been published", $item->id));
-
-				return;
 			}
-
-			$this->io->caution(sprintf("Item %u has NOT been published -- Please check manually", $item->id));
+            else
+            {
+    			$this->io->caution(sprintf("Item %u has NOT been published -- Please check manually", $item->id));
+            }
 		}
 	}
 


### PR DESCRIPTION
We are uploading multiple items (each their own zip file) to a release using a pattern match, like plg_*.zip

The Items and Publish steps have for loops to go over each file, but the code uses a return after the first file is successfully processed.

This update fixes the loops so they properly process all files matched.